### PR TITLE
Fix argument declaration for floating point numbers

### DIFF
--- a/types.lua
+++ b/types.lua
@@ -84,7 +84,7 @@ for _,typename in ipairs({"real", "unsigned char", "char", "short", "int", "long
       declare = function(arg)
                    -- if it is a number we initialize here
                    local default = tonumber(interpretdefaultvalue(arg)) or 0
-                   return string.format("%s arg%d = %d;", typename, arg.i, tonumber(default))
+                   return string.format("%s arg%d = %g;", typename, arg.i, default)
                 end,
 
       check = function(arg, idx)


### PR DESCRIPTION
Previously because of %d in the string, floating point numbers would have been initialized with floor(default) instead of default. This led to wrong initialization in torch.bernoulli (0 instead of 0.5)
